### PR TITLE
Add Spotless Maven Plugin with Eclipse JDT formatter for AOSP code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # android-xml-formatter
 
+[![GitHub check runs](https://img.shields.io/github/check-runs/ByteHamster/android-xml-formatter/develop)](https://github.com/ByteHamster/android-xml-formatter/actions/workflows/checks.yml?query=branch%3Amain)
+[![License: GPL v3](https://img.shields.io/github/license/ByteHamster/android-xml-formatter)](https://www.gnu.org/licenses/gpl-3.0)
+[![GitHub Release](https://img.shields.io/github/v/release/ByteHamster/android-xml-formatter)](https://github.com/ByteHamster/android-xml-formatter/releases)
+
 Formats XML files according to Android Studio's default formatting rules. By default, also re-orders the attributes to specify the `android:id`, `android:layout_width` and `android:layout_height` first. This can be turned off with a command line option.
 
 ## Requirements
@@ -9,24 +13,9 @@ Formats XML files according to Android Studio's default formatting rules. By def
 
 ## Building
 
-### Build the project
-
-```bash
-mvn clean package
-```
-
-This creates an executable JAR file with all dependencies at:
-```
-target/android-xml-formatter-1.0-SNAPSHOT-jar-with-dependencies.jar
-```
-
-### Run tests and verification
-
-```bash
-mvn verify
-```
-
-This runs all tests and code format checks.
+- `mvn clean package` to create an executable JAR file with all dependencies
+  at `target/android-xml-formatter-1.0-SNAPSHOT-jar-with-dependencies.jar`.
+- `mvn verify` runs all tests and code format checks.
 
 ## Usage
 
@@ -36,16 +25,14 @@ To view available command line options:
 java -jar target/android-xml-formatter-1.0-SNAPSHOT-jar-with-dependencies.jar --help
 ```
 
-### Command Line Options
-
-| Option | Description |
-|--------|-------------|
-| `--indention <n>` | Set indentation spaces (default: 4) |
-| `--attribute-indention <n>` | Set attribute indentation spaces (default: 4) |
-| `--attribute-order <list>` | Comma-separated attribute order (default: `id,layout_width,layout_height`) |
-| `--attribute-sort` | Sort attributes alphabetically |
-| `--namespace-order <list>` | Comma-separated namespace order (default: `android`) |
-| `--namespace-sort` | Sort namespaces alphabetically |
+| Option                      | Description                                                                |
+|-----------------------------|----------------------------------------------------------------------------|
+| `--indention <n>`           | Set indentation spaces (default: 4)                                        |
+| `--attribute-indention <n>` | Set attribute indentation spaces (default: 4)                              |
+| `--attribute-order <list>`  | Comma-separated attribute order (default: `id,layout_width,layout_height`) |
+| `--attribute-sort`          | Sort attributes alphabetically                                             |
+| `--namespace-order <list>`  | Comma-separated namespace order (default: `android`)                       |
+| `--namespace-sort`          | Sort namespaces alphabetically                                             |
 
 ### Example
 
@@ -61,56 +48,22 @@ Format multiple files:
 java -jar target/android-xml-formatter-1.0-SNAPSHOT-jar-with-dependencies.jar file1.xml file2.xml file3.xml
 ```
 
-## Code Formatting
+## Contributing
 
-This project uses [Spotless Maven Plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) with Eclipse JDT formatter for Java code formatting, configured to match the [AOSP (Android Open Source Project) code style](https://source.android.com/docs/setup/contribute/code-style).
+This project uses [Spotless Maven Plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven)
+with Eclipse JDT formatter for Java code formatting, configured to match the
+[AOSP (Android Open Source Project) code style](https://source.android.com/docs/setup/contribute/code-style).
 
-### Configuration
-
-- **Formatter**: Eclipse JDT
-- **Style**: AOSP (Android Open Source Project) - see `settings/eclipse-aosp-style.xml`
-- **Import Order**: AOSP style (android, androidx, com.android, dalvik, libcore, com, org, java, javax)
-- **Check Phase**: Runs automatically during `mvn verify`
-
-### Check code formatting
-
-To verify that all Java code follows the formatting rules:
-
-```bash
-mvn spotless:check
-```
-
-### Apply code formatting
-
-To automatically format all Java code:
-
-```bash
-mvn spotless:apply
-```
-
-### Formatting Rules
-
-The AOSP style enforces:
-- 4-space indentation
-- 100 character line length limit
-- Opening braces on same line
-- AOSP import ordering with blank lines between groups
-- Proper spacing around operators and keywords
-- Preserved line breaks in method chains (won't join manually wrapped lines)
-
-> **Note:** Always run `mvn spotless:apply` before committing to ensure consistent formatting.
+To verify that all Java code follows the formatting rules, run `mvn spotless:check`.
+To automatically format all Java code, run `mvn spotless:apply`.
 
 ## CI Integration
 
-Can be used as a style check on a CI server by executing the formatter and then printing the diff:
+This project can be used as a style check on a CI server by executing the formatter and then printing the diff:
 
 ```bash
-# Check XML formatting
 java -jar android-xml-formatter.jar *.xml
 git diff --exit-code
-
-# Check Java code formatting
-mvn spotless:check
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,7 +1,118 @@
 # android-xml-formatter
 
-Formats xml files according to Android Studio's default formatting rules. By default, also re-orders the attributes to specify the `android:id`, `android:layout_width` and `android:layout_height` first. This can be turned off with a command line option.
+Formats XML files according to Android Studio's default formatting rules. By default, also re-orders the attributes to specify the `android:id`, `android:layout_width` and `android:layout_height` first. This can be turned off with a command line option.
 
-To view available command line options, execute `java -jar android-xml-formatter.jar --help`.
+## Requirements
 
-Can be used as a style check on a CI server by executing and then printing the diff.
+- Java 8 or higher
+- Maven 3.6 or higher
+
+## Building
+
+### Build the project
+
+```bash
+mvn clean package
+```
+
+This creates an executable JAR file with all dependencies at:
+```
+target/android-xml-formatter-1.0-SNAPSHOT-jar-with-dependencies.jar
+```
+
+### Run tests and verification
+
+```bash
+mvn verify
+```
+
+This runs all tests and code format checks.
+
+## Usage
+
+To view available command line options:
+
+```bash
+java -jar target/android-xml-formatter-1.0-SNAPSHOT-jar-with-dependencies.jar --help
+```
+
+### Command Line Options
+
+| Option | Description |
+|--------|-------------|
+| `--indention <n>` | Set indentation spaces (default: 4) |
+| `--attribute-indention <n>` | Set attribute indentation spaces (default: 4) |
+| `--attribute-order <list>` | Comma-separated attribute order (default: `id,layout_width,layout_height`) |
+| `--attribute-sort` | Sort attributes alphabetically |
+| `--namespace-order <list>` | Comma-separated namespace order (default: `android`) |
+| `--namespace-sort` | Sort namespaces alphabetically |
+
+### Example
+
+Format an XML file:
+
+```bash
+java -jar target/android-xml-formatter-1.0-SNAPSHOT-jar-with-dependencies.jar path/to/layout.xml
+```
+
+Format multiple files:
+
+```bash
+java -jar target/android-xml-formatter-1.0-SNAPSHOT-jar-with-dependencies.jar file1.xml file2.xml file3.xml
+```
+
+## Code Formatting
+
+This project uses [Spotless Maven Plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) with Eclipse JDT formatter for Java code formatting, configured to match the [AOSP (Android Open Source Project) code style](https://source.android.com/docs/setup/contribute/code-style).
+
+### Configuration
+
+- **Formatter**: Eclipse JDT
+- **Style**: AOSP (Android Open Source Project) - see `settings/eclipse-aosp-style.xml`
+- **Import Order**: AOSP style (android, androidx, com.android, dalvik, libcore, com, org, java, javax)
+- **Check Phase**: Runs automatically during `mvn verify`
+
+### Check code formatting
+
+To verify that all Java code follows the formatting rules:
+
+```bash
+mvn spotless:check
+```
+
+### Apply code formatting
+
+To automatically format all Java code:
+
+```bash
+mvn spotless:apply
+```
+
+### Formatting Rules
+
+The AOSP style enforces:
+- 4-space indentation
+- 100 character line length limit
+- Opening braces on same line
+- AOSP import ordering with blank lines between groups
+- Proper spacing around operators and keywords
+- Preserved line breaks in method chains (won't join manually wrapped lines)
+
+> **Note:** Always run `mvn spotless:apply` before committing to ensure consistent formatting.
+
+## CI Integration
+
+Can be used as a style check on a CI server by executing the formatter and then printing the diff:
+
+```bash
+# Check XML formatting
+java -jar android-xml-formatter.jar *.xml
+git diff --exit-code
+
+# Check Java code formatting
+mvn spotless:check
+```
+
+## License
+
+See [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # android-xml-formatter
 
-[![GitHub check runs](https://img.shields.io/github/check-runs/ByteHamster/android-xml-formatter/develop)](https://github.com/ByteHamster/android-xml-formatter/actions/workflows/checks.yml?query=branch%3Amain)
+[![GitHub check runs](https://img.shields.io/github/check-runs/ByteHamster/android-xml-formatter/main)](https://github.com/ByteHamster/android-xml-formatter/actions/workflows/checks.yml?query=branch%3Amain)
 [![License: GPL v3](https://img.shields.io/github/license/ByteHamster/android-xml-formatter)](https://www.gnu.org/licenses/gpl-3.0)
 [![GitHub Release](https://img.shields.io/github/v/release/ByteHamster/android-xml-formatter)](https://github.com/ByteHamster/android-xml-formatter/releases)
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,32 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.43.0</version>
+                <configuration>
+                    <java>
+                        <!-- Eclipse JDT formatter with AOSP code style -->
+                        <eclipse>
+                            <file>${project.basedir}/settings/eclipse-aosp-style.xml</file>
+                        </eclipse>
+                        <!-- Import ordering matching AOSP style -->
+                        <importOrder>
+                            <order>android,androidx,com.android,dalvik,libcore,com,org,java,javax,</order>
+                        </importOrder>
+                        <removeUnusedImports/>
+                    </java>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.1.1</version>
                 <configuration>

--- a/settings/eclipse-aosp-style.xml
+++ b/settings/eclipse-aosp-style.xml
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Eclipse formatter configuration matching AOSP (Android Open Source Project) code style.
+  Based on: https://source.android.com/docs/setup/contribute/code-style
+
+  Licensed under the Apache License, Version 2.0
+-->
+<profiles version="21">
+    <profile kind="CodeFormatterProfile" name="AOSP" version="21">
+        <!-- Indentation: 4 spaces -->
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+
+        <!-- Line width: 100 characters -->
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
+
+        <!-- Braces: same line -->
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+
+        <!-- Blank lines -->
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+
+        <!-- Spaces -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+
+        <!-- Wrapping -->
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+
+        <!-- New lines -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+
+        <!-- Keep settings -->
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+
+        <!-- Comments -->
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+
+        <!-- Other -->
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+    </profile>
+</profiles>

--- a/src/main/java/com/bytehamster/androidxmlformatter/AndroidXmlOutputter.java
+++ b/src/main/java/com/bytehamster/androidxmlformatter/AndroidXmlOutputter.java
@@ -1,11 +1,5 @@
 package com.bytehamster.androidxmlformatter;
 
-import java.io.IOException;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
 import org.jdom.Attribute;
 import org.jdom.CDATA;
@@ -19,6 +13,12 @@ import org.jdom.Verifier;
 import org.jdom.output.Format;
 import org.jdom.output.XMLOutputter;
 
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 public class AndroidXmlOutputter extends XMLOutputter {
     final String[] namespaceOrder;
     final String[] attributeNameOrder;
@@ -27,8 +27,8 @@ public class AndroidXmlOutputter extends XMLOutputter {
     final boolean alphabeticalNamespaces;
 
     public AndroidXmlOutputter(int indention, int attributeIndention,
-                               String[] namespaceOrder, String[] attributeNameOrder,
-                               boolean alphabeticalAttributes, boolean alphabeticalNamespaces) {
+            String[] namespaceOrder, String[] attributeNameOrder,
+            boolean alphabeticalAttributes, boolean alphabeticalNamespaces) {
         this.attributeIndention = attributeIndention;
         this.namespaceOrder = namespaceOrder;
         this.attributeNameOrder = attributeNameOrder;
@@ -51,7 +51,8 @@ public class AndroidXmlOutputter extends XMLOutputter {
         return result;
     }
 
-    private void printNamespace(Writer out, Namespace ns, XMLOutputter.NamespaceStack namespaces) throws IOException {
+    private void printNamespace(Writer out, Namespace ns, XMLOutputter.NamespaceStack namespaces)
+            throws IOException {
         String prefix = ns.getPrefix();
         String uri = ns.getURI();
         if (!uri.equals(namespaces.getURI(prefix))) {
@@ -67,7 +68,9 @@ public class AndroidXmlOutputter extends XMLOutputter {
             namespaces.push(ns);
         }
     }
-    private void printElementNamespace(Writer out, Element element, XMLOutputter.NamespaceStack namespaces) throws IOException {
+
+    private void printElementNamespace(Writer out, Element element,
+            XMLOutputter.NamespaceStack namespaces) throws IOException {
         Namespace ns = element.getNamespace();
         if (ns != Namespace.XML_NAMESPACE) {
             if (ns != Namespace.NO_NAMESPACE || namespaces.getURI("") != null) {
@@ -77,11 +80,12 @@ public class AndroidXmlOutputter extends XMLOutputter {
         }
     }
 
-    private void printAdditionalNamespaces(Writer out, Element element, XMLOutputter.NamespaceStack namespaces) throws IOException {
+    private void printAdditionalNamespaces(Writer out, Element element,
+            XMLOutputter.NamespaceStack namespaces) throws IOException {
         List list = element.getAdditionalNamespaces();
         if (list != null) {
-            for(int i = 0; i < list.size(); ++i) {
-                Namespace additional = (Namespace)list.get(i);
+            for (int i = 0; i < list.size(); ++i) {
+                Namespace additional = (Namespace) list.get(i);
                 if (attributeIndention > 0) {
                     newline(out);
                     indent(out, elementDepth(element) - 1);
@@ -105,7 +109,7 @@ public class AndroidXmlOutputter extends XMLOutputter {
         if (this.currentFormat.getTextMode() == Format.TextMode.TRIM_FULL_WHITE
                 || this.currentFormat.getTextMode() == Format.TextMode.NORMALIZE
                 || this.currentFormat.getTextMode() == Format.TextMode.TRIM) {
-            while(index >= 0 && this.isAllWhitespace(content.get(index - 1))) {
+            while (index >= 0 && this.isAllWhitespace(content.get(index - 1))) {
                 --index;
             }
         }
@@ -116,7 +120,7 @@ public class AndroidXmlOutputter extends XMLOutputter {
     private boolean isAllWhitespace(Object obj) {
         String str = null;
         if (obj instanceof String) {
-            str = (String)obj;
+            str = (String) obj;
         } else {
             if (!(obj instanceof Text)) {
                 if (obj instanceof EntityRef) {
@@ -126,10 +130,10 @@ public class AndroidXmlOutputter extends XMLOutputter {
                 return false;
             }
 
-            str = ((Text)obj).getText();
+            str = ((Text) obj).getText();
         }
 
-        for(int i = 0; i < str.length(); ++i) {
+        for (int i = 0; i < str.length(); ++i) {
             if (!Verifier.isXMLWhitespace(str.charAt(i))) {
                 return false;
             }
@@ -146,7 +150,7 @@ public class AndroidXmlOutputter extends XMLOutputter {
         int index = start;
         int size = content.size();
         if (true) {
-            while(index < size) {
+            while (index < size) {
                 if (!this.isAllWhitespace(content.get(index))) {
                     return index;
                 }
@@ -166,7 +170,7 @@ public class AndroidXmlOutputter extends XMLOutputter {
         int index = start;
 
         int size;
-        for(size = content.size(); index < size; ++index) {
+        for (size = content.size(); index < size; ++index) {
             Object node = content.get(index);
             if (!(node instanceof Text) && !(node instanceof EntityRef)) {
                 return index;
@@ -176,11 +180,12 @@ public class AndroidXmlOutputter extends XMLOutputter {
         return size;
     }
 
-    private void printContentRange(Writer out, List content, int start, int end, int level, XMLOutputter.NamespaceStack namespaces) throws IOException {
+    private void printContentRange(Writer out, List content, int start, int end, int level,
+            XMLOutputter.NamespaceStack namespaces) throws IOException {
         int index = start;
 
-        while(true) {
-            while(index < end) {
+        while (true) {
+            while (index < end) {
                 boolean firstNode = index == start;
                 Object next = content.get(index);
                 if (!(next instanceof Text) && !(next instanceof EntityRef)) {
@@ -190,11 +195,11 @@ public class AndroidXmlOutputter extends XMLOutputter {
 
                     this.indent(out, level);
                     if (next instanceof Comment) {
-                        this.printComment(out, (Comment)next);
+                        this.printComment(out, (Comment) next);
                     } else if (next instanceof Element) {
-                        this.printElement(out, (Element)next, level, namespaces);
+                        this.printElement(out, (Element) next, level, namespaces);
                     } else if (next instanceof ProcessingInstruction) {
-                        this.printProcessingInstruction(out, (ProcessingInstruction)next);
+                        this.printProcessingInstruction(out, (ProcessingInstruction) next);
                     }
 
                     ++index;
@@ -233,30 +238,32 @@ public class AndroidXmlOutputter extends XMLOutputter {
         if (start < size) {
             end = this.skipTrailingWhite(content, end);
 
-            for(int i = start; i < end; ++i) {
+            for (int i = start; i < end; ++i) {
                 Object node = content.get(i);
                 String next;
                 if (node instanceof Text) {
-                    next = ((Text)node).getText();
+                    next = ((Text) node).getText();
                 } else {
                     if (!(node instanceof EntityRef)) {
-                        throw new IllegalStateException("Should see only CDATA, Text, or EntityRef");
+                        throw new IllegalStateException(
+                                "Should see only CDATA, Text, or EntityRef");
                     }
 
-                    next = "&" + ((EntityRef)node).getValue() + ";";
+                    next = "&" + ((EntityRef) node).getValue() + ";";
                 }
 
                 if (next != null && !"".equals(next)) {
-                    if (previous != null && (this.currentFormat.getTextMode() == Format.TextMode.NORMALIZE
-                            || this.currentFormat.getTextMode() == Format.TextMode.TRIM)
+                    if (previous != null
+                            && (this.currentFormat.getTextMode() == Format.TextMode.NORMALIZE
+                                    || this.currentFormat.getTextMode() == Format.TextMode.TRIM)
                             && (this.endsWithWhite(previous) || this.startsWithWhite(next))) {
                         out.write(" ");
                     }
 
                     if (node instanceof CDATA) {
-                        this.printCDATA(out, (CDATA)node);
+                        this.printCDATA(out, (CDATA) node);
                     } else if (node instanceof EntityRef) {
-                        this.printEntityRef(out, (EntityRef)node);
+                        this.printEntityRef(out, (EntityRef) node);
                     } else {
                         this.printString(out, next);
                     }
@@ -273,11 +280,13 @@ public class AndroidXmlOutputter extends XMLOutputter {
     }
 
     private boolean endsWithWhite(String str) {
-        return str != null && str.length() > 0 && Verifier.isXMLWhitespace(str.charAt(str.length() - 1));
+        return str != null && str.length() > 0
+                && Verifier.isXMLWhitespace(str.charAt(str.length() - 1));
     }
 
     @Override
-    protected void printElement(Writer out, Element element, int level, NamespaceStack namespaces) throws IOException {
+    protected void printElement(Writer out, Element element, int level, NamespaceStack namespaces)
+            throws IOException {
         List attributes = element.getAttributes();
         List content = element.getContent();
         String space = null;
@@ -322,7 +331,7 @@ public class AndroidXmlOutputter extends XMLOutputter {
             out.write(">");
         }
 
-        while(namespaces.size() > previouslyDeclaredNamespaces) {
+        while (namespaces.size() > previouslyDeclaredNamespaces) {
             namespaces.pop();
         }
 
@@ -335,13 +344,14 @@ public class AndroidXmlOutputter extends XMLOutputter {
     }
 
     private void indent(Writer out, int level) throws IOException {
-        for(int i = 0; i < level; ++i) {
+        for (int i = 0; i < level; ++i) {
             out.write(getFormat().getIndent());
         }
     }
 
     @Override
-    protected void printAttributes(Writer writer, List attribs, Element parent, NamespaceStack ns) throws IOException {
+    protected void printAttributes(Writer writer, List attribs, Element parent, NamespaceStack ns)
+            throws IOException {
         List<Attribute> attributes = new ArrayList<>();
         for (Object attribObj : attribs) {
             attributes.add((Attribute) attribObj);

--- a/src/main/java/com/bytehamster/androidxmlformatter/Main.java
+++ b/src/main/java/com/bytehamster/androidxmlformatter/Main.java
@@ -63,13 +63,15 @@ public class Main {
                     Integer.parseInt(cmd.getOptionValue("indention", "4")),
                     Integer.parseInt(cmd.getOptionValue("attribute-indention", "4")),
                     cmd.getOptionValue("namespace-order", "android").split(","),
-                    cmd.getOptionValue("attribute-order", "id,layout_width,layout_height").split(","),
+                    cmd.getOptionValue("attribute-order", "id,layout_width,layout_height")
+                            .split(","),
                     cmd.hasOption("attribute-sort"),
                     cmd.hasOption("namespace-sort"));
             ByteArrayOutputStream stream = new ByteArrayOutputStream();
             outputter.output(doc, stream);
             byte[] content = stream.toByteArray();
-            new FileOutputStream(filename).write(content, 0, content.length - 2); // Strip double line break
+            new FileOutputStream(filename).write(content, 0, content.length - 2); // Strip double
+                                                                                  // line break
         }
     }
 }


### PR DESCRIPTION
Configuration:
- Added Spotless Maven Plugin version 2.43.0
- Configured Eclipse JDT formatter with AOSP code style
- Added settings/eclipse-aosp-style.xml with AOSP formatting rules
- Import ordering: android, androidx, com.android, dalvik, libcore, com, org, java, javax
- Removes unused imports automatically
- Bound 'check' goal to 'verify' phase

Formatting Rules:
- 4-space indentation
- 100 character line length
- Opening braces on same line
- Preserved line breaks in method chains (join_wrapped_lines = false)
- AOSP import ordering with blank lines between groups

Additional Changes:
- Expanded README.md with build instructions, usage examples, and formatting documentation
- Reformatted Java source files with AOSP style

Verification:
- Ran 'mvn spotless:check' to verify configuration
- Confirmed formatting preserves preferred method chain style

Usage:
- mvn spotless:check  - Verify code formatting
- mvn spotless:apply  - Auto-format code to match the style